### PR TITLE
openPMD-api: 0.12.0

### DIFF
--- a/openPMD_to_gdf.py
+++ b/openPMD_to_gdf.py
@@ -27,7 +27,7 @@ def hdf_to_gdf(hdf_file_directory, gdf_file_directory, max_cell_size, species):
 
     print('Destination .gdf directory not specified. Defaulting to ' + gdf_file_directory)
 
-    series_hdf = openpmd_api.Series(hdf_file_directory, openpmd_api.Access_Type.read_only)
+    series_hdf = openpmd_api.Series(hdf_file_directory, openpmd_api.Access.read_only)
 
     with open(gdf_file_directory, 'wb') as gdf_file:
         hdf_file_to_gdf_file(gdf_file, series_hdf, max_cell_size, species)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # openPMD_to_gdf.py, gdf_to_openPMD.py
-openpmd-api>=0.10.3
+openpmd-api>=0.12.0,<0.13.0
 # gdf_to_openPMD.py
 matplotlib>=3.0.0
 # OpenPMD_add_patches.py


### PR DESCRIPTION
Updates a newly deprecated class to its new preferred name (`Access`).
https://openpmd-api.readthedocs.io/en/0.12.0-alpha/install/upgrade.html